### PR TITLE
Feat/overloaded_literal

### DIFF
--- a/src/interpreter/array.mbt
+++ b/src/interpreter/array.mbt
@@ -57,14 +57,14 @@ let array_zip_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 数组make操作
 let array_make_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(len), .. }, { val, .. }] => Array(Array::make(len, val))
+  [{ val: Int(len, ..), .. }, { val, .. }] => Array(Array::make(len, val))
   _ => Unit
 }
 
 ///|
 /// 数组new操作
 let array_new_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(len), kind: LabelledOption("capacity") }] =>
+  [{ val: Int(len, ..), kind: LabelledOption("capacity") }] =>
     Array(Array::new(capacity=len))
   _ => Array(Array::new())
 }
@@ -72,7 +72,7 @@ let array_new_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 数组长度
 let array_length_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Array(arr), .. }] => Int(arr.length())
+  [{ val: Array(arr), .. }] => Int(arr.length(), raw=None)
   _ => Unit
 }
 
@@ -128,7 +128,7 @@ let array_join_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 数组swap操作
 let array_swap_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Array(arr), .. }, { val: Int(i), .. }, { val: Int(j), .. }] => {
+  [{ val: Array(arr), .. }, { val: Int(i, ..), .. }, { val: Int(j, ..), .. }] => {
     arr.swap(i, j)
     Unit
   }
@@ -138,7 +138,7 @@ let array_swap_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 数组get操作
 let array_get_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Array(arr), .. }, { val: Int(i), .. }] =>
+  [{ val: Array(arr), .. }, { val: Int(i, ..), .. }] =>
     RuntimeValue::from_option(arr.get(i))
   _ => Unit
 }
@@ -156,7 +156,7 @@ let array_append_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 数组set操作
 let array_set_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Array(arr), .. }, { val: Int(i), .. }, { val, .. }] => {
+  [{ val: Array(arr), .. }, { val: Int(i, ..), .. }, { val, .. }] => {
     arr[i] = val
     Unit
   }
@@ -173,7 +173,7 @@ let array_pop_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 数组insert操作
 let array_insert_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Array(arr), .. }, { val: Int(i), .. }, { val, .. }] => {
+  [{ val: Array(arr), .. }, { val: Int(i, ..), .. }, { val, .. }] => {
     arr.insert(i, val)
     Unit
   }
@@ -183,7 +183,7 @@ let array_insert_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 数组remove操作
 let array_remove_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Array(arr), .. }, { val: Int(i), .. }] => arr.remove(i)
+  [{ val: Array(arr), .. }, { val: Int(i, ..), .. }] => arr.remove(i)
   _ => Unit
 }
 
@@ -198,14 +198,14 @@ let array_contains_fn : RuntimeFunction = ctx => match ctx.args {
 /// 数组search操作
 let array_search_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: Array(arr), .. }, { val, .. }] =>
-    RuntimeValue::from_option(arr.search(val).map(fn(i) { Int(i) }))
+    RuntimeValue::from_option(arr.search(val).map(fn(i) { Int(i, raw=None) }))
   _ => Unit
 }
 
 ///|
 /// 数组capacity操作
 let array_capacity_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Array(arr), .. }] => Int(arr.capacity())
+  [{ val: Array(arr), .. }] => Int(arr.capacity(), raw=None)
   _ => Unit
 }
 
@@ -214,7 +214,7 @@ let array_capacity_fn : RuntimeFunction = ctx => match ctx.args {
 let array_resize_fn : RuntimeFunction = ctx => match ctx.args {
   [
     { val: Array(arr), .. },
-    { val: Int(new_size), .. },
+    { val: Int(new_size, ..), .. },
     { val: fill_val, .. },
     ..,
   ] => {
@@ -227,7 +227,7 @@ let array_resize_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 数组truncate操作
 let array_truncate_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Array(arr), .. }, { val: Int(len), .. }] => {
+  [{ val: Array(arr), .. }, { val: Int(len, ..), .. }] => {
     arr.truncate(len)
     Unit
   }
@@ -237,7 +237,7 @@ let array_truncate_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 数组reserve_capacity操作
 let array_reserve_capacity_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Array(arr), .. }, { val: Int(additional), .. }] => {
+  [{ val: Array(arr), .. }, { val: Int(additional, ..), .. }] => {
     arr.reserve_capacity(additional)
     Unit
   }
@@ -262,7 +262,7 @@ let array_eachi_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: Array(arr), .. }, { val: Fn(f), .. }] => {
     arr.eachi(fn(i, val) {
       ctx.context.call(f.val, ctx.pkg, [
-        { val: Int(i), kind: Positional },
+        { val: Int(i, raw=None), kind: Positional },
         { val, kind: Positional },
       ])
       |> ignore
@@ -290,7 +290,7 @@ let array_mapi_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: Array(arr), .. }, { val: Fn(f), .. }] => {
     let new_arr = arr.mapi(fn(i, val) {
       ctx.context.call(f.val, ctx.pkg, [
-        { val: Int(i), kind: Positional },
+        { val: Int(i, raw=None), kind: Positional },
         { val, kind: Positional },
       ])
     })
@@ -333,7 +333,7 @@ let array_search_by_fn : RuntimeFunction = ctx => match ctx.args {
         { val, kind: Positional },
       ]))
       is Ok(Bool(true)))
-    RuntimeValue::from_option(index.map(Int(_)))
+    RuntimeValue::from_option(index.map(Int(_, raw=None)))
   }
   _ => Unit
 }
@@ -350,7 +350,7 @@ let array_iter2_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: Array(arr), .. }] =>
     Iter2(
       Iter2::new(yield_ => for i, v in arr {
-        guard yield_(Int(i), v) is IterContinue else { break IterEnd }
+        guard yield_(Int(i, raw=None), v) is IterContinue else { break IterEnd }
       } else {
         IterContinue
       }),

--- a/src/interpreter/array_view.mbt
+++ b/src/interpreter/array_view.mbt
@@ -29,7 +29,7 @@ pub let array_view_methods : Map[String, RuntimeFunction] = {
 ///|
 /// 数组长度
 let array_view_length_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: ArrayView(arr), .. }] => Int(arr.length())
+  [{ val: ArrayView(arr), .. }] => Int(arr.length(), raw=None)
   _ => Unit
 }
 
@@ -52,14 +52,14 @@ let array_view_buf_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// ArrayView start 方法 - 返回起始索引
 let array_view_start_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: ArrayView(arr), .. }] => Int(arr.start())
+  [{ val: ArrayView(arr), .. }] => Int(arr.start(), raw=None)
   _ => Unit
 }
 
 ///|
 /// ArrayView len 方法
 let array_view_len_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: ArrayView(arr), .. }] => Int(arr.len())
+  [{ val: ArrayView(arr), .. }] => Int(arr.len(), raw=None)
   _ => Unit
 }
 
@@ -114,7 +114,7 @@ let array_view_each_fn : RuntimeFunction = ctx => match ctx.args {
 let array_view_eachi_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: ArrayView(arr), .. }, { val: Fn(f), .. }] => {
     arr.eachi((i, elem) => ctx.context.call(f.val, ctx.pkg, [
-        { val: Int(i), kind: Positional },
+        { val: Int(i, raw=None), kind: Positional },
         { val: elem, kind: Positional },
       ])
       |> ignore)
@@ -155,7 +155,7 @@ let array_view_foldi_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: ArrayView(arr), .. }, { val: init, .. }, { val: Fn(f), .. }] =>
     arr.foldi(init~, fn(i, acc, elem) {
       ctx.context.call(f.val, ctx.pkg, [
-        { val: Int(i), kind: Positional },
+        { val: Int(i, raw=None), kind: Positional },
         { val: acc, kind: Positional },
         { val: elem, kind: Positional },
       ])
@@ -176,7 +176,7 @@ let array_view_iter2_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: ArrayView(self), .. }] =>
     Iter2(
       Iter2::new(yield_ => for i, v in self {
-        guard yield_(Int(i), v) is IterContinue else { break IterEnd }
+        guard yield_(Int(i, raw=None), v) is IterContinue else { break IterEnd }
       } else {
         IterContinue
       }),
@@ -210,7 +210,7 @@ let array_view_mapi_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: ArrayView(arr), .. }, { val: Fn(f), .. }] =>
     Array(
       arr.mapi((i, elem) => ctx.context.call(f.val, ctx.pkg, [
-        { val: Int(i), kind: Positional },
+        { val: Int(i, raw=None), kind: Positional },
         { val: elem, kind: Positional },
       ])),
     )
@@ -236,7 +236,7 @@ let array_view_rev_foldi_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: ArrayView(arr), .. }, { val: init, .. }, { val: Fn(f), .. }] =>
     arr.rev_foldi(init~, fn(i, acc, elem) {
       ctx.context.call(f.val, ctx.pkg, [
-        { val: Int(i), kind: Positional },
+        { val: Int(i, raw=None), kind: Positional },
         { val: acc, kind: Positional },
         { val: elem, kind: Positional },
       ])

--- a/src/interpreter/assignment_operations.mbt
+++ b/src/interpreter/assignment_operations.mbt
@@ -40,14 +40,16 @@ fn ClosureInterpreter::visit_field_augmented_assignment(
     Object(refer) =>
       match accessor {
         Label(label) => {
-          let current_val = refer.val.get(label.name).unwrap_or(Int(0))
+          let current_val = refer.val
+            .get(label.name)
+            .unwrap_or(Int(0, raw=None))
           let new_val = runtime_value_infix(base_op, current_val, right_val)
           refer.val.set(label.name, new_val)
         }
         Index(tuple_index~, ..) => {
           let current_val = refer.val
             .get(tuple_index.to_string())
-            .unwrap_or(Int(0))
+            .unwrap_or(Int(0, raw=None))
           let new_val = runtime_value_infix(base_op, current_val, right_val)
           refer.val.set(tuple_index.to_string(), new_val)
         }
@@ -92,7 +94,7 @@ fn ClosureInterpreter::visit_array_set(
     Array(arr) => {
       let index = self.visit(index)
       match index {
-        Int(index) => {
+        Int(index, ..) => {
           let value = self.visit(value)
           arr[index] = value
         }

--- a/src/interpreter/builtin.mbt
+++ b/src/interpreter/builtin.mbt
@@ -208,37 +208,37 @@ let println_mono_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 整数取负
 let int_neg_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Int(-i)
+  [{ val: Int(i, ..), .. }] => Int(-i, raw=None)
   _ => Unit
 }
 
 ///|
 /// 整数加法
 let int_add_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(a), .. }, { val: Int(b), .. }] => Int(a + b)
+  [{ val: Int(a, ..), .. }, { val: Int(b, ..), .. }] => Int(a + b, raw=None)
   _ => Unit
 }
 
 ///|
 /// 整数减法
 let int_sub_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(a), .. }, { val: Int(b), .. }] => Int(a - b)
+  [{ val: Int(a, ..), .. }, { val: Int(b, ..), .. }] => Int(a - b, raw=None)
   _ => Unit
 }
 
 ///|
 /// 整数乘法
 let int_mul_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(a), .. }, { val: Int(b), .. }] => Int(a * b)
+  [{ val: Int(a, ..), .. }, { val: Int(b, ..), .. }] => Int(a * b, raw=None)
   _ => Unit
 }
 
 ///|
 /// 整数除法
 let int_div_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(a), .. }, { val: Int(b), .. }] =>
+  [{ val: Int(a, ..), .. }, { val: Int(b, ..), .. }] =>
     if b != 0 {
-      Int(a / b)
+      Int(a / b, raw=None)
     } else {
       abort("division by zero")
       Unit
@@ -249,9 +249,9 @@ let int_div_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 整数取模
 let int_mod_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(a), .. }, { val: Int(b), .. }] =>
+  [{ val: Int(a, ..), .. }, { val: Int(b, ..), .. }] =>
     if b != 0 {
-      Int(a % b)
+      Int(a % b, raw=None)
     } else {
       abort("modulo by zero")
       Unit
@@ -310,13 +310,13 @@ let bool_eq_fn : RuntimeFunction = ctx => match ctx.args {
 let bool_compare_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: Bool(a), .. }, { val: Bool(b), .. }] =>
     if a == b {
-      Int(0)
+      Int(0, raw=None)
     } else if a {
-      Int(1) // true > false
+      Int(1, raw=None) // true > false
     } else {
-      Int(-1) // false < true
+      Int(-1, raw=None) // false < true
     }
-  _ => Int(0)
+  _ => Int(0, raw=None)
 }
 
 ///|
@@ -328,7 +328,7 @@ let bool_default_fn : RuntimeFunction = _ctx => Bool(false)
 ///|
 /// 转换为 Double
 let to_double_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Double(i.to_double())
+  [{ val: Int(i, ..), .. }] => Double(i.to_double())
   [{ val: Float(f), .. }] => Double(f.to_double())
   [{ val: Double(d), .. }] => Double(d)
   [{ val: UInt(u), .. }] => Double(u.to_double())
@@ -340,7 +340,7 @@ let to_double_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 转换为 Float
 let to_float_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Float(i.to_float())
+  [{ val: Int(i, ..), .. }] => Float(i.to_float())
   [{ val: Float(f), .. }] => Float(f)
   [{ val: Double(d), .. }] => Float(d.to_float())
   [{ val: UInt(u), .. }] => Float(u.to_float())
@@ -350,7 +350,7 @@ let to_float_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 转换为 Byte
 let to_byte_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Byte(i.to_byte())
+  [{ val: Int(i, ..), .. }] => Byte(i.to_byte())
   [{ val: UInt(u), .. }] => Byte(u.to_byte())
   [{ val: Byte(b), .. }] => Byte(b)
   _ => Unit
@@ -359,22 +359,22 @@ let to_byte_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 转换为 Int16 (使用 Int 表示)
 let to_int16_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Int(i & 0xFFFF)
-  [{ val: UInt(u), .. }] => Int(u.reinterpret_as_int() & 0xFFFF)
+  [{ val: Int(i, ..), .. }] => Int(i & 0xFFFF, raw=None)
+  [{ val: UInt(u), .. }] => Int(u.reinterpret_as_int() & 0xFFFF, raw=None)
   _ => Unit
 }
 
 ///|
 /// 转换为 UInt16 
 let to_uint16_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => UInt16(i.to_uint16())
+  [{ val: Int(i, ..), .. }] => UInt16(i.to_uint16())
   _ => Unit
 }
 
 ///|
 /// 转换为 Int64
 let to_int64_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Int64(i.to_int64())
+  [{ val: Int(i, ..), .. }] => Int64(i.to_int64())
   [{ val: UInt(u), .. }] => Int64(u.to_int64())
   [{ val: Int64(i64), .. }] => Int64(i64)
   [{ val: UInt64(u64), .. }] => Int64(u64.reinterpret_as_int64())
@@ -385,7 +385,7 @@ let to_int64_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 转换为 UInt64
 let to_uint64_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => UInt64(i.to_uint64())
+  [{ val: Int(i, ..), .. }] => UInt64(i.to_uint64())
   [{ val: UInt(u), .. }] => UInt64(u.to_uint64())
   [{ val: Int64(i64), .. }] => UInt64(i64.reinterpret_as_uint64())
   [{ val: UInt64(u64), .. }] => UInt64(u64)
@@ -439,14 +439,14 @@ let uint_eq_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// UInt 比较
 let uint_compare_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: UInt(a), .. }, { val: UInt(b), .. }] => Int(a.compare(b))
+  [{ val: UInt(a), .. }, { val: UInt(b), .. }] => Int(a.compare(b), raw=None)
   _ => Unit
 }
 
 ///|
 /// UInt 转 Int
 let uint_to_int_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: UInt(u), .. }] => Int(u.reinterpret_as_int())
+  [{ val: UInt(u), .. }] => Int(u.reinterpret_as_int(), raw=None)
   _ => Unit
 }
 
@@ -497,7 +497,7 @@ let float_eq_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// Float 比较
 let float_compare_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Float(a), .. }, { val: Float(b), .. }] => Int(a.compare(b))
+  [{ val: Float(a), .. }, { val: Float(b), .. }] => Int(a.compare(b), raw=None)
   _ => Unit
 }
 
@@ -548,7 +548,8 @@ let double_eq_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// Double 比较
 let double_compare_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Double(a), .. }, { val: Double(b), .. }] => Int(a.compare(b))
+  [{ val: Double(a), .. }, { val: Double(b), .. }] =>
+    Int(a.compare(b), raw=None)
   _ => Unit
 }
 
@@ -571,14 +572,14 @@ let char_eq_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// Char 比较
 let char_compare_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Char(a), .. }, { val: Char(b), .. }] => Int(a.compare(b))
+  [{ val: Char(a), .. }, { val: Char(b), .. }] => Int(a.compare(b), raw=None)
   _ => Unit
 }
 
 ///|
 /// Char 转 Int
 let char_to_int_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Char(c), .. }] => Int(c.to_int())
+  [{ val: Char(c), .. }] => Int(c.to_int(), raw=None)
   _ => Unit
 }
 
@@ -592,7 +593,7 @@ let char_to_string_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// Char 从 Int 构造
 let char_from_int_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Char(i.unsafe_to_char())
+  [{ val: Int(i, ..), .. }] => Char(i.unsafe_to_char())
   _ => Unit
 }
 
@@ -608,14 +609,14 @@ let byte_eq_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// Byte 比较
 let byte_compare_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Byte(a), .. }, { val: Byte(b), .. }] => Int(a.compare(b))
+  [{ val: Byte(a), .. }, { val: Byte(b), .. }] => Int(a.compare(b), raw=None)
   _ => Unit
 }
 
 ///|
 /// Byte 转 Int
 let byte_to_int_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Byte(b), .. }] => Int(b.to_int())
+  [{ val: Byte(b), .. }] => Int(b.to_int(), raw=None)
   _ => Unit
 }
 
@@ -673,14 +674,14 @@ let int64_eq_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// Int64 比较
 let int64_compare_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int64(a), .. }, { val: Int64(b), .. }] => Int(a.compare(b))
+  [{ val: Int64(a), .. }, { val: Int64(b), .. }] => Int(a.compare(b), raw=None)
   _ => Unit
 }
 
 ///|
 /// Int64 转 Int
 let int64_to_int_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int64(i64), .. }] => Int(i64.to_int())
+  [{ val: Int64(i64), .. }] => Int(i64.to_int(), raw=None)
   _ => Unit
 }
 
@@ -738,7 +739,8 @@ let uint64_eq_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// UInt64 比较
 let uint64_compare_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: UInt64(a), .. }, { val: UInt64(b), .. }] => Int(a.compare(b))
+  [{ val: UInt64(a), .. }, { val: UInt64(b), .. }] =>
+    Int(a.compare(b), raw=None)
   _ => Unit
 }
 

--- a/src/interpreter/bytes.mbt
+++ b/src/interpreter/bytes.mbt
@@ -14,13 +14,13 @@ pub let bytes_methods : Map[String, RuntimeFunction] = {
 
 ///|
 let bytes_at_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Bytes(b), .. }, { val: Int(i), .. }] => Byte(b[i])
+  [{ val: Bytes(b), .. }, { val: Int(i, ..), .. }] => Byte(b[i])
   _ => Unit
 }
 
 ///|
 let bytes_compare_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Bytes(a), .. }, { val: Bytes(b), .. }] => Int(a.compare(b))
+  [{ val: Bytes(a), .. }, { val: Bytes(b), .. }] => Int(a.compare(b), raw=None)
   _ => Unit
 }
 
@@ -32,16 +32,16 @@ let bytes_equal_fn : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let bytes_make_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(len), .. }, { val: Byte(byte), .. }] =>
+  [{ val: Int(len, ..), .. }, { val: Byte(byte), .. }] =>
     Bytes(Bytes::make(len, byte))
   _ => Unit
 }
 
 ///|
 let bytes_makei_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(len), .. }, { val: Fn(f), .. }] => {
+  [{ val: Int(len, ..), .. }, { val: Fn(f), .. }] => {
     let result = Bytes::makei(len, fn(i) {
-      let arg = Int(i)
+      let arg = Int(i, raw=None)
       let ret = ctx.context.call(f.val, ctx.pkg, [
         { val: arg, kind: Positional },
       ])
@@ -57,7 +57,7 @@ let bytes_makei_fn : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let bytes_new_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(len), .. }] => Bytes(Bytes::new(len))
+  [{ val: Int(len, ..), .. }] => Bytes(Bytes::new(len))
   _ => Unit
 }
 
@@ -70,12 +70,12 @@ let bytes_op_equal_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 let bytes_to_unchecked_string_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: Bytes(b), .. }] => {
-    let offset = if ctx.named("offset") is Some(Int(i)) {
+    let offset = if ctx.named("offset") is Some(Int(i, ..)) {
       Some(i)
     } else {
       None
     }
-    let length = if ctx.named("length") is Some(Int(i)) {
+    let length = if ctx.named("length") is Some(Int(i, ..)) {
       Some(i)
     } else {
       None
@@ -87,12 +87,12 @@ let bytes_to_unchecked_string_fn : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let bytes_unsafe_get_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Bytes(b), .. }, { val: Int(i), .. }] => Byte(b.unsafe_get(i))
+  [{ val: Bytes(b), .. }, { val: Int(i, ..), .. }] => Byte(b.unsafe_get(i))
   _ => Unit
 }
 
 ///|
 let bytes_length_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Bytes(b), .. }] => Int(b.length())
+  [{ val: Bytes(b), .. }] => Int(b.length(), raw=None)
   _ => Unit
 }

--- a/src/interpreter/expression_visitors.mbt
+++ b/src/interpreter/expression_visitors.mbt
@@ -40,7 +40,7 @@ fn ClosureInterpreter::visit_unary_expression(
       let val = self.visit(expr)
       match (name, val) {
         ("!", Bool(value)) => Bool(!value)
-        ("-", Int(value)) => Int(-value)
+        ("-", Int(value, ..)) => Int(-value, raw=None)
         ("-", Double(value)) => Double(-value)
         _ => Unit
       }
@@ -241,7 +241,7 @@ fn ClosureInterpreter::visit_field(
   let record_val = self.visit(record)
   match (record_val, accessor) {
     (String(str), Index(tuple_index~, ..)) =>
-      RuntimeValue::from_option(str.get(tuple_index).map(Int(_)))
+      RuntimeValue::from_option(str.get(tuple_index).map(Int(_, raw=None)))
     (Object({ val: fields, .. }), Label(label)) =>
       match fields.get(label.name) {
         Some(field_value) => field_value

--- a/src/interpreter/fixedarray.mbt
+++ b/src/interpreter/fixedarray.mbt
@@ -29,14 +29,14 @@ let fixedarray_new_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// FixedArray::length 操作 - 获取数组长度
 let fixedarray_length_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: FixedArray(arr), .. }] => Int(arr.length())
+  [{ val: FixedArray(arr), .. }] => Int(arr.length(), raw=None)
   _ => Unit
 }
 
 ///|
 /// FixedArray::get 操作 - 安全获取元素
 let fixedarray_get_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: FixedArray(arr), .. }, { val: Int(i), .. }] =>
+  [{ val: FixedArray(arr), .. }, { val: Int(i, ..), .. }] =>
     if i >= 0 && i < arr.length() {
       arr[i]
     } else {
@@ -48,7 +48,7 @@ let fixedarray_get_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// FixedArray::set 操作 - 设置元素
 let fixedarray_set_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: FixedArray(arr), .. }, { val: Int(i), .. }, { val, .. }] => {
+  [{ val: FixedArray(arr), .. }, { val: Int(i, ..), .. }, { val, .. }] => {
     if i >= 0 && i < arr.length() {
       arr[i] = val
     }
@@ -60,14 +60,14 @@ let fixedarray_set_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// FixedArray::unsafe_get 操作 - 不安全获取元素
 let fixedarray_unsafe_get_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: FixedArray(arr), .. }, { val: Int(i), .. }] => arr[i]
+  [{ val: FixedArray(arr), .. }, { val: Int(i, ..), .. }] => arr[i]
   _ => Unit
 }
 
 ///|
 /// FixedArray::unsafe_set 操作 - 不安全设置元素
 let fixedarray_unsafe_set_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: FixedArray(arr), .. }, { val: Int(i), .. }, { val, .. }] => {
+  [{ val: FixedArray(arr), .. }, { val: Int(i, ..), .. }, { val, .. }] => {
     arr[i] = val
     Unit
   }
@@ -77,7 +77,8 @@ let fixedarray_unsafe_set_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// FixedArray::make 操作 - 创建指定大小和初始值的固定数组
 let fixedarray_make_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(len), .. }, { val, .. }] => FixedArray(FixedArray::make(len, val))
+  [{ val: Int(len, ..), .. }, { val, .. }] =>
+    FixedArray(FixedArray::make(len, val))
   _ => Unit
 }
 
@@ -95,10 +96,10 @@ let fixedarray_fill_fn : RuntimeFunction = ctx => match ctx.args {
 /// FixedArray::blit_to 操作 - 复制数组内容
 let fixedarray_blit_to_fn : RuntimeFunction = ctx => match ctx.args {
   [
-    { val: Int(dst_offset), .. },
+    { val: Int(dst_offset, ..), .. },
     { val: FixedArray(src), .. },
-    { val: Int(src_offset), .. },
-    { val: Int(len), .. },
+    { val: Int(src_offset, ..), .. },
+    { val: Int(len, ..), .. },
   ] => {
     src.unsafe_blit(dst_offset, src, src_offset, len)
     Unit
@@ -111,10 +112,10 @@ let fixedarray_blit_to_fn : RuntimeFunction = ctx => match ctx.args {
 let fixedarray_unsafe_blit_fn : RuntimeFunction = ctx => match ctx.args {
   [
     { val: FixedArray(dst), .. },
-    { val: Int(dst_offset), .. },
+    { val: Int(dst_offset, ..), .. },
     { val: FixedArray(src), .. },
-    { val: Int(src_offset), .. },
-    { val: Int(len), .. },
+    { val: Int(src_offset, ..), .. },
+    { val: Int(len, ..), .. },
   ] => {
     dst.unsafe_blit(dst_offset, src, src_offset, len)
     Unit
@@ -142,7 +143,7 @@ let fixedarray_iter2_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: FixedArray(arr), .. }] => {
     let iter2_impl = Iter2::new(yield_fn => {
       for i in 0..<arr.length() {
-        match yield_fn(Int(i), arr[i]) {
+        match yield_fn(Int(i, raw=None), arr[i]) {
           IterEnd => return IterEnd
           IterContinue => ()
         }
@@ -158,7 +159,7 @@ let fixedarray_iter2_fn : RuntimeFunction = ctx => match ctx.args {
 /// FixedArray::binary_search 操作 - 二分查找
 let fixedarray_binary_search_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: FixedArray(arr), .. }, { val: target, .. }] =>
-    arr.binary_search(target).map(Int(_)).map_err(Int(_))
+    arr.binary_search(target).map(Int(_, raw=None)).map_err(Int(_, raw=None))
     |> RuntimeValue::from_result
   _ => Unit
 }
@@ -170,11 +171,11 @@ let fixedarray_binary_search_by_fn : RuntimeFunction = ctx => match ctx.args {
     arr
     .binary_search_by(v => match
       ctx.context.call(f.val, ctx.pkg, [{ val: v, kind: Positional }]) {
-      Int(i) => i
+      Int(i, ..) => i
       _ => raise Error("binary_search_by closure must return int")
     })
-    .map(Int(_))
-    .map_err(Int(_))
+    .map(Int(_, raw=None))
+    .map_err(Int(_, raw=None))
     |> RuntimeValue::from_result
   _ => Unit
 }
@@ -184,14 +185,14 @@ let fixedarray_binary_search_by_fn : RuntimeFunction = ctx => match ctx.args {
 let fixedarray_set_utf16le_char_fn : RuntimeFunction = ctx => match ctx.args {
   [
     { val: FixedArray(self), .. },
-    { val: Int(offset), .. },
+    { val: Int(offset, ..), .. },
     { val: Char(value), .. },
   ] => {
     let code = value.to_uint()
     if code < 0x10000 {
       self[offset] = Byte((code & 0xFF).to_byte())
       self[offset + 1] = Byte((code >> 8).to_byte())
-      Int(2)
+      Int(2, raw=None)
     } else if code < 0x110000 {
       let hi = code - 0x10000
       let lo = (hi >> 10) | 0xD800
@@ -200,7 +201,7 @@ let fixedarray_set_utf16le_char_fn : RuntimeFunction = ctx => match ctx.args {
       self[offset + 1] = Byte((lo >> 8).to_byte())
       self[offset + 2] = Byte((hi & 0xFF).to_byte())
       self[offset + 3] = Byte((hi >> 8).to_byte())
-      Int(4)
+      Int(4, raw=None)
     } else {
       error("Char out of range")
     }
@@ -213,14 +214,14 @@ let fixedarray_set_utf16le_char_fn : RuntimeFunction = ctx => match ctx.args {
 let fixedarray_set_utf16be_char_fn : RuntimeFunction = ctx => match ctx.args {
   [
     { val: FixedArray(self), .. },
-    { val: Int(offset), .. },
+    { val: Int(offset, ..), .. },
     { val: Char(value), .. },
   ] => {
     let code = value.to_uint()
     if code < 0x10000 {
       self[offset] = Byte((code >> 8).to_byte())
       self[offset + 1] = Byte((code & 0xFF).to_byte())
-      Int(2)
+      Int(2, raw=None)
     } else if code < 0x110000 {
       let hi = code - 0x10000
       let lo = (hi >> 10) | 0xD800
@@ -229,7 +230,7 @@ let fixedarray_set_utf16be_char_fn : RuntimeFunction = ctx => match ctx.args {
       self[offset + 1] = Byte((lo & 0xFF).to_byte())
       self[offset + 2] = Byte((hi >> 8).to_byte())
       self[offset + 3] = Byte((hi & 0xFF).to_byte())
-      Int(4)
+      Int(4, raw=None)
     } else {
       error("Char out of range")
     }

--- a/src/interpreter/hashmap.mbt
+++ b/src/interpreter/hashmap.mbt
@@ -57,7 +57,7 @@ let hash_map_is_empty_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// HashMap capacity操作
 let hash_map_capacity_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: HashMap(map), .. }] => Int(map.capacity())
+  [{ val: HashMap(map), .. }] => Int(map.capacity(), raw=None)
   _ => Unit
 }
 
@@ -111,7 +111,7 @@ let hash_map_eachi_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: HashMap(map), .. }, { val: Fn(f), .. }] => {
     map.eachi(fn(i, key, val) {
       ctx.context.call(f.val, ctx.pkg, [
-        { val: Int(i), kind: Positional },
+        { val: Int(i, raw=None), kind: Positional },
         { val: key, kind: Positional },
         { val, kind: Positional },
       ])
@@ -229,7 +229,7 @@ let hash_map_keys_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// HashMap length操作
 let hash_map_length_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: HashMap(map), .. }] => Int(map.length())
+  [{ val: HashMap(map), .. }] => Int(map.length(), raw=None)
   _ => Unit
 }
 
@@ -318,7 +318,7 @@ let hash_map_set_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// HashMap size操作
 let hash_map_size_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: HashMap(map), .. }] => Int(map.length())
+  [{ val: HashMap(map), .. }] => Int(map.length(), raw=None)
   _ => Unit
 }
 

--- a/src/interpreter/int.mbt
+++ b/src/interpreter/int.mbt
@@ -39,42 +39,42 @@ pub let int_embedded_code : Map[String, RuntimeFunction] = {
 ///|
 /// 整数按位取反
 let int_lnot_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Int(i.lnot())
+  [{ val: Int(i, ..), .. }] => Int(i.lnot(), raw=None)
   _ => Unit
 }
 
 ///|
 /// 整数按位与
 let int_land_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(a), .. }, { val: Int(b), .. }] => Int(a & b)
+  [{ val: Int(a, ..), .. }, { val: Int(b, ..), .. }] => Int(a & b, raw=None)
   _ => Unit
 }
 
 ///|
 /// 整数按位或
 let int_lor_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(a), .. }, { val: Int(b), .. }] => Int(a | b)
+  [{ val: Int(a, ..), .. }, { val: Int(b, ..), .. }] => Int(a | b, raw=None)
   _ => Unit
 }
 
 ///|
 /// 整数按位异或
 let int_lxor_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(a), .. }, { val: Int(b), .. }] => Int(a ^ b)
+  [{ val: Int(a, ..), .. }, { val: Int(b, ..), .. }] => Int(a ^ b, raw=None)
   _ => Unit
 }
 
 ///|
 /// 整数左移
 let int_shl_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(a), .. }, { val: Int(b), .. }] => Int(a << b)
+  [{ val: Int(a, ..), .. }, { val: Int(b, ..), .. }] => Int(a << b, raw=None)
   _ => Unit
 }
 
 ///|
 /// 整数右移
 let int_shr_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(a), .. }, { val: Int(b), .. }] => Int(a >> b)
+  [{ val: Int(a, ..), .. }, { val: Int(b, ..), .. }] => Int(a >> b, raw=None)
   _ => Unit
 }
 
@@ -83,35 +83,35 @@ let int_shr_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 整数相等比较
 let int_eq_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(a), .. }, { val: Int(b), .. }] => Bool(a == b)
+  [{ val: Int(a, ..), .. }, { val: Int(b, ..), .. }] => Bool(a == b)
   _ => Bool(false)
 }
 
 ///|
 /// 整数比较
 let int_compare_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(a), .. }, { val: Int(b), .. }] =>
+  [{ val: Int(a, ..), .. }, { val: Int(b, ..), .. }] =>
     if a == b {
-      Int(0)
+      Int(0, raw=None)
     } else if a > b {
-      Int(1)
+      Int(1, raw=None)
     } else {
-      Int(-1)
+      Int(-1, raw=None)
     }
-  _ => Int(0)
+  _ => Int(0, raw=None)
 }
 
 ///|
 /// 整数是否为正
 let int_is_pos_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Bool(i > 0)
+  [{ val: Int(i, ..), .. }] => Bool(i > 0)
   _ => Bool(false)
 }
 
 ///|
 /// 整数是否为负
 let int_is_neg_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Bool(i < 0)
+  [{ val: Int(i, ..), .. }] => Bool(i < 0)
   _ => Bool(false)
 }
 
@@ -120,34 +120,34 @@ let int_is_neg_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// 计算尾随零的个数
 let int_ctz_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Int(i.ctz())
+  [{ val: Int(i, ..), .. }] => Int(i.ctz(), raw=None)
   _ => Unit
 }
 
 ///|
 /// 计算前导零的个数
 let int_clz_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Int(i.clz())
+  [{ val: Int(i, ..), .. }] => Int(i.clz(), raw=None)
   _ => Unit
 }
 
 ///|
 /// 计算设置位的个数
 let int_popcnt_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Int(i.popcnt())
+  [{ val: Int(i, ..), .. }] => Int(i.popcnt(), raw=None)
   _ => Unit
 }
 
 ///|
 /// 整数转字符串
 let int_to_string_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => String(i.to_string())
+  [{ val: Int(i, ..), .. }] => String(i.to_string())
   _ => Unit
 }
 
 ///|
 /// 计算不小于该整数的最小2的幂
 let int_next_power_of_two_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(i), .. }] => Int(i.next_power_of_two())
+  [{ val: Int(i, ..), .. }] => Int(i.next_power_of_two(), raw=None)
   _ => Unit
 }

--- a/src/interpreter/interpreter.mbt
+++ b/src/interpreter/interpreter.mbt
@@ -266,7 +266,8 @@ pub fn ClosureInterpreter::top_visit(
     // 处理顶层常量定义（如 const Zero = 0）
     TopLetDef(binder~, expr~, ..) => {
       let value = self.visit(expr) catch { _ => Unit }
-      self.current_pkg.values.set(binder.name, value)
+      let name = binder.name
+      self.current_pkg.env.set(name, value)
       value
     }
     TopTypeDef(def) => {
@@ -786,7 +787,10 @@ pub fn ClosureInterpreter::visit(
           self.find_pkg(pkg).env
           .find(name)
           .unwrap_or(self.current_pkg.cons(name, []))
-        _ => self.current_pkg.cons(name, [])
+        _ =>
+          self.current_pkg.env
+          .find(name)
+          .unwrap_or(self.current_pkg.cons(name, []))
       }
     }
     // 处理 Break 表达式

--- a/src/interpreter/interpreter.mbt
+++ b/src/interpreter/interpreter.mbt
@@ -511,9 +511,9 @@ pub fn ClosureInterpreter::visit(
         Array(arr) =>
           ArrayView(
             match (start, end) {
-              (Some(Int(start)), Some(Int(end))) => arr[start:end]
-              (Some(Int(start)), None) => arr[start:]
-              (None, Some(Int(end))) => arr[:end]
+              (Some(Int(start, ..)), Some(Int(end, ..))) => arr[start:end]
+              (Some(Int(start, ..)), None) => arr[start:]
+              (None, Some(Int(end, ..))) => arr[:end]
               _ => arr[:]
             },
           )
@@ -542,7 +542,7 @@ pub fn ClosureInterpreter::visit(
         Array(arr) => {
           let index = self.visit(index)
           match (index, op) {
-            (Int(index), { name: Ident(name=op), .. }) => {
+            (Int(index, ..), { name: Ident(name=op), .. }) => {
               let value = self.visit(value)
               arr[index] = runtime_value_infix(op, arr[index], value)
             }
@@ -687,10 +687,10 @@ pub fn ClosureInterpreter::visit(
       let array_val = self.visit(array)
       let index_val = self.visit(index)
       match (array_val, index_val) {
-        (Array(values), Int(index_num)) => values[index_num]
-        (ArrayView(values), Int(index_num)) => values[index_num]
-        (UninitializedArray(values), Int(index_num)) => values[index_num]
-        (String(values), Int(index_num)) => Int(values[index_num])
+        (Array(values), Int(index_num, ..)) => values[index_num]
+        (ArrayView(values), Int(index_num, ..)) => values[index_num]
+        (UninitializedArray(values), Int(index_num, ..)) => values[index_num]
+        (String(values), Int(index_num, ..)) => Int(values[index_num], raw=None)
         (Map(values), index) =>
           match values.get(index) {
             Some(value) => value
@@ -900,12 +900,12 @@ pub fn ClosureInterpreter::visit(
               let start_val = self.visit(lhs)
               let end_val = self.visit(rhs)
               match (start_val, end_val) {
-                (Int(start), Int(end)) =>
+                (Int(start, ..), Int(end, ..)) =>
                   Some(
                     RuntimeValue::Iter(
                       Iter::new(visit_fn => {
                         for i in start..<end {
-                          match visit_fn(Int(i)) {
+                          match visit_fn(Int(i, raw=None)) {
                             IterEnd => return IterEnd
                             IterContinue => ()
                           }
@@ -921,12 +921,12 @@ pub fn ClosureInterpreter::visit(
               let start_val = self.visit(lhs)
               let end_val = self.visit(rhs)
               match (start_val, end_val) {
-                (Int(start), Int(end)) =>
+                (Int(start, ..), Int(end, ..)) =>
                   Some(
                     RuntimeValue::Iter(
                       Iter::new(visit_fn => {
                         for i in start..=end {
-                          match visit_fn(Int(i)) {
+                          match visit_fn(Int(i, raw=None)) {
                             IterEnd => return IterEnd
                             IterContinue => ()
                           }

--- a/src/interpreter/iter.mbt
+++ b/src/interpreter/iter.mbt
@@ -84,8 +84,8 @@ let iter_to_array_fn : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let iter_count_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Iter(iter), .. }] => Int(iter.count())
-  _ => Int(0)
+  [{ val: Iter(iter), .. }] => Int(iter.count(), raw=None)
+  _ => Int(0, raw=None)
 }
 
 // Element access
@@ -104,7 +104,7 @@ let iter_last_fn : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let iter_nth_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Iter(iter), .. }, { val: Int(n), .. }] =>
+  [{ val: Iter(iter), .. }, { val: Int(n, ..), .. }] =>
     RuntimeValue::from_option(iter.nth(n))
   _ => Unit
 }
@@ -145,21 +145,24 @@ let iter_intersperse_fn : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let iter_take_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Iter(iter), .. }, { val: Int(n), .. }] => Iter(iter.take(n))
+  [{ val: Iter(iter), .. }, { val: Int(n, ..), .. }] => Iter(iter.take(n))
   _ => Unit
 }
 
 ///|
 let iter_drop_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Iter(iter), .. }, { val: Int(n), .. }] => Iter(iter.drop(n))
+  [{ val: Iter(iter), .. }, { val: Int(n, ..), .. }] => Iter(iter.drop(n))
   _ => Unit
 }
 
 ///|
 let iter_op_as_view_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Iter(iter), .. }, { val: Int(start), .. }, { val: Int(end), .. }] =>
-    Iter(iter.op_as_view(start~, end~))
-  [{ val: Iter(iter), .. }, { val: Int(start), .. }] =>
+  [
+    { val: Iter(iter), .. },
+    { val: Int(start, ..), .. },
+    { val: Int(end, ..), .. },
+  ] => Iter(iter.op_as_view(start~, end~))
+  [{ val: Iter(iter), .. }, { val: Int(start, ..), .. }] =>
     Iter(iter.op_as_view(start~))
   [{ val: iter_val, .. }] => iter_val
   _ => Unit
@@ -323,7 +326,7 @@ let iter_eachi_fn : RuntimeFunction = ctx => match ctx.args {
     iter.eachi(fn(index, val) {
       try {
         let _ = ctx.context.call(func.val, ctx.pkg, [
-          { val: Int(index), kind: Positional },
+          { val: Int(index, raw=None), kind: Positional },
           { val, kind: Positional },
         ])
 
@@ -411,7 +414,7 @@ let iter_iter2_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: Iter(iter), .. }] => {
     // iter2 converts an iterator to an indexed iterator
     let result : Iter[RuntimeValue] = iter.mapi(fn(index, val) {
-      Tuple([Int(index), val])
+      Tuple([Int(index, raw=None), val])
     })
     Iter(result)
   }
@@ -474,7 +477,10 @@ let iter_mapi_fn : RuntimeFunction = ctx => match ctx.args {
     let result = iter.mapi((index, val) => try! ctx.context.call(
         func.val,
         ctx.pkg,
-        [{ val: Int(index), kind: Positional }, { val, kind: Positional }],
+        [
+          { val: Int(index, raw=None), kind: Positional },
+          { val, kind: Positional },
+        ],
       ))
     Iter(result)
   }

--- a/src/interpreter/map.mbt
+++ b/src/interpreter/map.mbt
@@ -47,7 +47,7 @@ let map_is_empty_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// Map capacity操作
 let map_capacity_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Map(map), .. }] => Int(map.capacity())
+  [{ val: Map(map), .. }] => Int(map.capacity(), raw=None)
   _ => Unit
 }
 
@@ -95,7 +95,7 @@ let map_eachi_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: Map(map), .. }, { val: Fn(f), .. }] => {
     map.eachi(fn(i, key, val) {
       ctx.context.call(f.val, ctx.pkg, [
-        { val: Int(i), kind: Positional },
+        { val: Int(i, raw=None), kind: Positional },
         { val: key, kind: Positional },
         { val, kind: Positional },
       ])
@@ -266,7 +266,7 @@ let map_set_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 /// Map size操作
 let map_size_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Map(map), .. }] => Int(map.length())
+  [{ val: Map(map), .. }] => Int(map.length(), raw=None)
   _ => Unit
 }
 

--- a/src/interpreter/option.mbt
+++ b/src/interpreter/option.mbt
@@ -257,8 +257,8 @@ let option_unwrap_or_default_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: Constructor({ val: { name: "None", fields: [] }, .. }), .. }] =>
     // 返回默认值，对于数值类型返回0，其他类型返回Unit
     // 这里简化实现，实际应该根据泛型类型参数确定默认值
-    Int(0)
-  _ => Int(0)
+    Int(0, raw=None)
+  _ => Int(0, raw=None)
 }
 
 ///|

--- a/src/interpreter/pattern_matching.mbt
+++ b/src/interpreter/pattern_matching.mbt
@@ -185,7 +185,7 @@ pub fn ClosureInterpreter::match_case(
     // 常量模式匹配
     Constant(c=pattern_const, ..) =>
       match (value, pattern_const) {
-        (Int(v), Int(s)) => {
+        (Int(v, ..), Int(s)) => {
           let pattern_int = @strconv.parse_int(s) catch { _ => 0 }
           v == pattern_int
         }
@@ -342,7 +342,7 @@ pub fn ClosureInterpreter::match_case(
             .unwrap_or(Unit)
           match (value, constr_runtime_value) {
             // 如果构造函数是常量值，直接比较
-            (Int(v1), Int(v2)) => v1 == v2
+            (Int(v1, ..), Int(v2, ..)) => v1 == v2
             (Bool(v1), Bool(v2)) => v1 == v2
             (String(v1), String(v2)) => v1 == v2
             (Double(v1), Double(v2)) => v1 == v2
@@ -381,7 +381,7 @@ pub fn ClosureInterpreter::runtime_value_in_range(
   let lhs_value = self.pattern_to_runtime_value(lhs)
   let rhs_value = self.pattern_to_runtime_value(rhs)
   match (value, lhs_value, rhs_value) {
-    (Int(v), Some(Int(start)), Some(Int(end))) =>
+    (Int(v, ..), Some(Int(start, ..)), Some(Int(end, ..))) =>
       if inclusive {
         v >= start && v <= end
       } else {
@@ -400,14 +400,14 @@ pub fn ClosureInterpreter::runtime_value_in_range(
         v >= start && v < end
       }
     // 处理开放范围（如 _..<Zero 或 1..<_）
-    (Int(v), None, Some(Int(end))) =>
+    (Int(v, ..), None, Some(Int(end, ..))) =>
       // 左边界是通配符，如 _..<Zero
       if inclusive {
         v <= end
       } else {
         v < end
       }
-    (Int(v), Some(Int(start)), None) =>
+    (Int(v, ..), Some(Int(start, ..)), None) =>
       // 右边界是通配符，如 1..<_
       v >= start
     (Double(v), None, Some(Double(end))) =>
@@ -439,7 +439,7 @@ pub fn ClosureInterpreter::pattern_to_runtime_value(
       match c {
         Int(v) => {
           let int_val = @strconv.parse_int(v) catch { _ => return None }
-          Some(Int(int_val))
+          Some(Int(int_val, raw=None))
         }
         Double(v) => {
           let double_val = @strconv.parse_double(v) catch { _ => return None }

--- a/src/interpreter/pkg.generated.mbti
+++ b/src/interpreter/pkg.generated.mbti
@@ -271,7 +271,7 @@ impl ToJson for RuntimeType
 pub(all) enum RuntimeValue {
   Unit
   Bool(Bool)
-  Int(Int)
+  Int(Int, raw~ : String?)
   UInt(UInt)
   UInt16(UInt16)
   Int64(Int64)

--- a/src/interpreter/record_operations.mbt
+++ b/src/interpreter/record_operations.mbt
@@ -60,7 +60,9 @@ fn ClosureInterpreter::visit_mutate(
                 "%" => "%"
                 _ => "+" // 默认
               }
-              let current_val = refer.val.get(label.name).unwrap_or(Int(0))
+              let current_val = refer.val
+                .get(label.name)
+                .unwrap_or(Int(0, raw=None))
               let right_val = self.visit(field)
               let new_val = runtime_value_infix(base_op, current_val, right_val)
               refer.val.set(label.name, new_val)
@@ -87,7 +89,7 @@ fn ClosureInterpreter::visit_mutate(
               }
               let current_val = refer.val
                 .get(tuple_index.to_string())
-                .unwrap_or(Int(0))
+                .unwrap_or(Int(0, raw=None))
               let right_val = self.visit(field)
               let new_val = runtime_value_infix(base_op, current_val, right_val)
               refer.val.set(tuple_index.to_string(), new_val)

--- a/src/interpreter/runtime_value.mbt
+++ b/src/interpreter/runtime_value.mbt
@@ -19,7 +19,7 @@ pub(all) enum RuntimeValue {
   // 基本值类型
   Unit
   Bool(Bool)
-  Int(Int)
+  Int(Int, raw~ : String?)
   UInt(UInt)
   UInt16(UInt16)
   Int64(Int64)
@@ -77,7 +77,7 @@ pub suberror ControlFlow {
 ///|
 pub impl Compare for RuntimeValue with compare(self, other) {
   match (self, other) {
-    (Int(a), Int(b)) => a.compare(b)
+    (Int(a, ..), Int(b, ..)) => a.compare(b)
     (UInt(a), UInt(b)) => a.compare(b)
     (Int64(a), Int64(b)) => a.compare(b)
     (UInt64(a), UInt64(b)) => a.compare(b)
@@ -111,7 +111,7 @@ pub impl Add for RuntimeValue with add(
   other : RuntimeValue,
 ) -> RuntimeValue {
   match (self, other) {
-    (Int(a), Int(b)) => Int(a + b)
+    (Int(a, ..), Int(b, ..)) => Int(a + b, raw=None)
     (UInt(a), UInt(b)) => UInt(a + b)
     (Int64(a), Int64(b)) => Int64(a + b)
     (UInt64(a), UInt64(b)) => UInt64(a + b)
@@ -152,7 +152,7 @@ pub impl Hash for RuntimeValue with hash(self : RuntimeValue) -> Int {
   match self {
     Unit => 0
     Bool(b) => b.hash()
-    Int(i) => i.hash()
+    Int(i, ..) => i.hash()
     UInt(u) => u.hash()
     Int64(i) => i.hash()
     UInt64(u) => u.hash()
@@ -178,7 +178,7 @@ pub impl ToJson for RuntimeValue with to_json(self : RuntimeValue) -> Json {
     Map(m) => m.to_json()
     Unit => Json::null()
     Bool(b) => b.to_json()
-    Int(i) => i.to_json()
+    Int(i, ..) => i.to_json()
     UInt(u) => u.to_json()
     Int64(i) => i.to_json()
     UInt16(u) => u.to_json()
@@ -223,7 +223,7 @@ pub impl Eq for RuntimeValue with equal(
     // 基本值类型比较
     (Unit, Unit) => true
     (Bool(a), Bool(b)) => a == b
-    (Int(a), Int(b)) => a == b
+    (Int(a, ..), Int(b, ..)) => a == b
     (UInt(a), UInt(b)) => a == b
     (Int64(a), Int64(b)) => a == b
     (UInt64(a), UInt64(b)) => a == b
@@ -323,7 +323,8 @@ test "parse_double" {
 fn RuntimeValue::from_constant(c : @syntax.Constant) -> RuntimeValue {
   match c {
     Bool(b) => Bool(b)
-    Int(s) => Int(@strconv.parse_int64(s).to_int() catch { _ => 0 })
+    Int(s) =>
+      Int(@strconv.parse_int64(s).to_int() catch { _ => 0 }, raw=Some(s))
     UInt(s) => UInt(@strconv.parse_uint64(s).to_uint() catch { _ => 0U })
     Int64(s) => Int64(@strconv.parse_int64(s) catch { _ => 0L })
     UInt64(s) => UInt64(@strconv.parse_uint64(s) catch { _ => 0UL })
@@ -371,27 +372,31 @@ pub fn RuntimeValue::overload_literal(
 ) -> RuntimeValue {
   match (self, expected_type) {
     // 数字字面量重载 (默认Int -> 其他数字类型)
-    (Int(i), "UInt") => UInt(i.reinterpret_as_uint())
-    (Int(i), "Int64") => Int64(i.to_int64())
-    (Int(i), "UInt64") => UInt64(i.to_uint64())
-    (Int(i), "UInt16") => UInt16(i.to_uint16())
-    (Int(i), "Byte") => Byte(i.to_byte())
-    (Int(i), "Double") => Double(i.to_double())
-    (Int(i), "Float") => Float(i.to_float())
-    (Int(i), "BigInt") => BigInt(BigInt::from_int(i))
+    (Int(_, raw=Some(raw)), "UInt") =>
+      UInt(@strconv.parse_uint64(raw).to_uint() catch { _ => 0U })
+    (Int(_, raw=Some(raw)), "Int64") =>
+      Int64(@strconv.parse_int64(raw) catch { _ => 0L })
+    (Int(_, raw=Some(raw)), "UInt64") =>
+      UInt64(@strconv.parse_uint64(raw) catch { _ => 0UL })
+    (Int(_, raw=Some(raw)), "UInt16") =>
+      UInt16(@strconv.parse_uint64(raw).to_uint16() catch { _ => 0 })
+    (Int(i, ..), "Byte") => Byte(i.to_byte())
+    (Int(i, ..), "Double") => Double(i.to_double())
+    (Int(i, ..), "Float") => Float(i.to_float())
+    (Int(i, ..), "BigInt") => BigInt(BigInt::from_int(i))
 
     // 字符串字面量重载 (默认String -> Bytes)
     (String(s), "Bytes") => Bytes(@encoding.encode(UTF8, s))
 
     // 字符字面量重载 (默认Char -> Int/Byte)
-    (Char(c), "Int") => Int(c.to_int())
+    (Char(c), "Int") => Int(c.to_int(), raw=None)
     (Char(c), "Byte") => Byte(c.to_int().to_byte())
 
     // 浮点数字面量重载 (默认Double -> Float)
     (Double(d), "Float") => Float(d.to_float())
 
     // JSON 类型重载 - 支持基本类型到 JSON 的转换
-    (Int(i), "Json") => Json(i.to_json())
+    (Int(i, ..), "Json") => Json(i.to_json())
     (Double(d), "Json") => Json(d.to_json())
     (String(s), "Json") => Json(s.to_json())
     (Bool(b), "Json") => Json(b.to_json())
@@ -428,7 +433,7 @@ pub fn RuntimeValue::overload_literal(
       let bytes = []
       for i = 0; i < arr.length(); i = i + 1 {
         match arr[i] {
-          Int(n) => bytes.push(n.to_byte())
+          Int(n, ..) => bytes.push(n.to_byte())
           Byte(b) => bytes.push(b)
           _ => return self // 如果不是Int数组，返回原值
         }
@@ -625,7 +630,7 @@ pub impl Show for RuntimeValue with to_string(self) -> String {
   match self {
     Unit => "()"
     Bool(b) => b.to_string()
-    Int(i) => i.to_string()
+    Int(i, ..) => i.to_string()
     UInt(u) => u.to_string()
     UInt16(u) => u.to_string()
     Int64(i64) => i64.to_string()
@@ -765,7 +770,7 @@ pub fn RuntimeValue::iter2(self : RuntimeValue) -> RuntimeValue {
       // 将数组转换为 Iter2，每个元素是 (index, value) 元组
       let iter_impl = Iter2::new(fn(f) {
         for i = 0; i < arr.length(); i = i + 1 {
-          match f(Int(i), arr[i]) {
+          match f(Int(i, raw=None), arr[i]) {
             IterEnd => return IterEnd
             IterContinue => ()
           }
@@ -779,7 +784,7 @@ pub fn RuntimeValue::iter2(self : RuntimeValue) -> RuntimeValue {
       let chars = str.to_array()
       let iter_impl = Iter2::new(fn(f) {
         for i = 0; i < chars.length(); i = i + 1 {
-          match f(Int(i), Char(chars[i])) {
+          match f(Int(i, raw=None), Char(chars[i])) {
             IterEnd => return IterEnd
             IterContinue => ()
           }
@@ -794,7 +799,7 @@ pub fn RuntimeValue::iter2(self : RuntimeValue) -> RuntimeValue {
       let chars = str.to_array()
       let iter_impl = Iter2::new(f => {
         for i = 0; i < chars.length(); i = i + 1 {
-          match f(Int(i), Char(chars[i])) {
+          match f(Int(i, raw=None), Char(chars[i])) {
             IterEnd => return IterEnd
             IterContinue => ()
           }
@@ -816,17 +821,25 @@ pub fn runtime_value_infix(
 ) -> RuntimeValue {
   match (lhs, rhs) {
     // Int 运算
-    (Int(left), Char(right)) =>
-      runtime_value_infix(op, Int(left), Int(right.to_int()))
-    (Char(left), Int(right)) =>
-      runtime_value_infix(op, Int(left.to_int()), Int(right))
-    (Int(left), Int(right)) =>
+    (Int(left, ..), Char(right)) =>
+      runtime_value_infix(
+        op,
+        Int(left, raw=None),
+        Int(right.to_int(), raw=None),
+      )
+    (Char(left), Int(right, ..)) =>
+      runtime_value_infix(
+        op,
+        Int(left.to_int(), raw=None),
+        Int(right, raw=None),
+      )
+    (Int(left, ..), Int(right, ..)) =>
       match op {
-        "+" => Int(left + right)
-        "-" => Int(left - right)
-        "*" => Int(left * right)
-        "/" => Int(left / right)
-        "%" => Int(left % right)
+        "+" => Int(left + right, raw=None)
+        "-" => Int(left - right, raw=None)
+        "*" => Int(left * right, raw=None)
+        "/" => Int(left / right, raw=None)
+        "%" => Int(left % right, raw=None)
         "==" => Bool(left == right)
         "!=" => Bool(left != right)
         "<" => Bool(left < right)

--- a/src/interpreter/string.mbt
+++ b/src/interpreter/string.mbt
@@ -56,25 +56,25 @@ let string_methods : Map[String, RuntimeFunction] = {
 
 ///|
 let string_length : RuntimeFunction = ctx => match ctx.args {
-  [{ val: String(s), .. }] => Int(s.length())
-  _ => Int(0)
+  [{ val: String(s), .. }] => Int(s.length(), raw=None)
+  _ => Int(0, raw=None)
 }
 
 ///|
 let string_get_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: String(s), .. }, { val: Int(i), .. }] =>
+  [{ val: String(s), .. }, { val: Int(i, ..), .. }] =>
     if i >= 0 && i < s.length() {
-      Int(s[i])
+      Int(s[i], raw=None)
     } else {
-      Int(0)
+      Int(0, raw=None)
     }
-  _ => Int(0)
+  _ => Int(0, raw=None)
 }
 
 ///|
 let string_unsafe_get_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: String(s), .. }, { val: Int(i), .. }] => Int(s[i])
-  _ => Int(0)
+  [{ val: String(s), .. }, { val: Int(i, ..), .. }] => Int(s[i], raw=None)
+  _ => Int(0, raw=None)
 }
 
 ///|
@@ -99,7 +99,7 @@ let string_to_string_fn : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let string_make_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: Int(len), .. }, { val: Char(value), .. }] =>
+  [{ val: Int(len, ..), .. }, { val: Char(value), .. }] =>
     String(String::make(len, value))
   _ => String("")
 }
@@ -135,7 +135,7 @@ let string_contains_char_fn : RuntimeFunction = ctx => Bool(
 ///|
 let string_find_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: String(str), .. }, { val: StringView(view), .. }] =>
-    RuntimeValue::from_option(str.find(view).map(Int(_)))
+    RuntimeValue::from_option(str.find(view).map(Int(_, raw=None)))
   _ => RuntimeValue::from_option(None)
 }
 
@@ -155,7 +155,7 @@ let string_find_by_fn : RuntimeFunction = ctx => match ctx.args {
           _ => false
         }
       })
-      .map(Int(_)),
+      .map(Int(_, raw=None)),
     )
   _ => RuntimeValue::from_option(None)
 }
@@ -208,7 +208,7 @@ let string_is_blank_fn : RuntimeFunction = ctx => match ctx.args {
 let string_pad_end_fn : RuntimeFunction = ctx => match ctx.args {
   [
     { val: String(s), .. },
-    { val: Int(total_width), .. },
+    { val: Int(total_width, ..), .. },
     { val: Char(padding_char), .. },
   ] => String(s.pad_end(total_width, padding_char))
   _ => String("")
@@ -218,7 +218,7 @@ let string_pad_end_fn : RuntimeFunction = ctx => match ctx.args {
 let string_pad_start_fn : RuntimeFunction = ctx => match ctx.args {
   [
     { val: String(s), .. },
-    { val: Int(total_width), .. },
+    { val: Int(total_width, ..), .. },
     { val: Char(padding_char), .. },
   ] => String(s.pad_start(total_width, padding_char))
   _ => String("")
@@ -226,7 +226,8 @@ let string_pad_start_fn : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let string_repeat_fn : RuntimeFunction = ctx => match ctx.args {
-  [{ val: String(s), .. }, { val: Int(count), .. }] => String(s.repeat(count))
+  [{ val: String(s), .. }, { val: Int(count, ..), .. }] =>
+    String(s.repeat(count))
   _ => String("")
 }
 
@@ -256,7 +257,7 @@ let string_rev_fn : RuntimeFunction = ctx => match ctx.args {
 ///|
 let string_rev_find_fn : RuntimeFunction = ctx => match ctx.args {
   [{ val: String(s), .. }, { val: String(substr), .. }] =>
-    RuntimeValue::from_option(s.rev_find(substr).map(Int(_)))
+    RuntimeValue::from_option(s.rev_find(substr).map(Int(_, raw=None)))
   _ => RuntimeValue::from_option(None)
 }
 
@@ -355,18 +356,18 @@ let string_trim_space_fn : RuntimeFunction = ctx => match ctx.args {
 let string_view_fn : RuntimeFunction = ctx => match ctx.args {
   [
     { val: String(s), .. },
-    { val: Int(start_offset), kind: Labelled("start_offset") },
-    { val: Int(end_offset), kind: Labelled("end_offset") },
+    { val: Int(start_offset, ..), kind: Labelled("start_offset") },
+    { val: Int(end_offset, ..), kind: Labelled("end_offset") },
     ..,
   ] => StringView(s.view(start_offset~, end_offset~))
   [
     { val: String(s), .. },
-    { val: Int(start_offset), kind: Labelled("start_offset") },
+    { val: Int(start_offset, ..), kind: Labelled("start_offset") },
     ..,
   ] => StringView(s.view(start_offset~))
   [
     { val: String(s), .. },
-    { val: Int(end_offset), kind: Labelled("end_offset") },
+    { val: Int(end_offset, ..), kind: Labelled("end_offset") },
     ..,
   ] => StringView(s.view(end_offset~))
   [{ val: String(s), .. }] => StringView(s.view())

--- a/src/interpreter/string_builder.mbt
+++ b/src/interpreter/string_builder.mbt
@@ -78,8 +78,8 @@ let stringbuilder_write_substring_fn : RuntimeFunction = ctx => match ctx.args {
   [
     { val: StringBuilder(self), .. },
     { val: String(str), .. },
-    { val: Int(start), .. },
-    { val: Int(len), .. },
+    { val: Int(start, ..), .. },
+    { val: Int(len, ..), .. },
   ] => {
     self.write_substring(str, start, len)
     Unit

--- a/src/interpreter/string_view.mbt
+++ b/src/interpreter/string_view.mbt
@@ -54,8 +54,8 @@ let string_view_methods : Map[String, RuntimeFunction] = {
 
 ///|
 let string_view_length : RuntimeFunction = ctx => match ctx.args {
-  [{ val: StringView(s), .. }] => Int(s.length())
-  _ => Int(0)
+  [{ val: StringView(s), .. }] => Int(s.length(), raw=None)
+  _ => Int(0, raw=None)
 }
 
 ///|
@@ -67,26 +67,27 @@ let string_view_add : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let string_view_at : RuntimeFunction = ctx => match ctx.args {
-  [{ val: StringView(s), .. }, { val: Int(i), .. }] => Int(s.at(i))
+  [{ val: StringView(s), .. }, { val: Int(i, ..), .. }] =>
+    Int(s.at(i), raw=None)
   _ => StringView("")
 }
 
 ///|
 let string_view_char_length : RuntimeFunction = ctx => match ctx.args {
-  [{ val: StringView(s), .. }] => Int(s.char_length())
-  _ => Int(0)
+  [{ val: StringView(s), .. }] => Int(s.char_length(), raw=None)
+  _ => Int(0, raw=None)
 }
 
 ///|
 let string_view_char_length_eq : RuntimeFunction = ctx => match ctx.args {
-  [{ val: StringView(s), .. }, { val: Int(n), .. }] =>
+  [{ val: StringView(s), .. }, { val: Int(n, ..), .. }] =>
     Bool(s.char_length() == n)
   _ => Bool(false)
 }
 
 ///|
 let string_view_char_length_ge : RuntimeFunction = ctx => match ctx.args {
-  [{ val: StringView(s), .. }, { val: Int(n), .. }] =>
+  [{ val: StringView(s), .. }, { val: Int(n, ..), .. }] =>
     Bool(s.char_length() >= n)
   _ => Bool(false)
 }
@@ -94,8 +95,8 @@ let string_view_char_length_ge : RuntimeFunction = ctx => match ctx.args {
 ///|
 let string_view_compare : RuntimeFunction = ctx => match ctx.args {
   [{ val: StringView(s1), .. }, { val: StringView(s2), .. }] =>
-    Int(s1.compare(s2))
-  _ => Int(0)
+    Int(s1.compare(s2), raw=None)
+  _ => Int(0, raw=None)
 }
 
 ///|
@@ -126,10 +127,10 @@ let string_view_equal : RuntimeFunction = ctx => match ctx.args {
 let string_view_find : RuntimeFunction = ctx => match ctx.args {
   [{ val: StringView(s), .. }, { val: StringView(sub), .. }] =>
     match s.find(sub) {
-      Some(i) => Int(i)
-      None => Int(-1)
+      Some(i) => Int(i, raw=None)
+      None => Int(-1, raw=None)
     }
-  _ => Int(-1)
+  _ => Int(-1, raw=None)
 }
 
 ///|
@@ -148,14 +149,14 @@ let string_view_fold : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let string_view_get : RuntimeFunction = ctx => match ctx.args {
-  [{ val: StringView(s), .. }, { val: Int(i), .. }] =>
-    s.get(i).map(Int(_)) |> RuntimeValue::from_option
+  [{ val: StringView(s), .. }, { val: Int(i, ..), .. }] =>
+    s.get(i).map(Int(_, raw=None)) |> RuntimeValue::from_option
   _ => StringView("")
 }
 
 ///|
 let string_view_get_char : RuntimeFunction = ctx => match ctx.args {
-  [{ val: StringView(s), .. }, { val: Int(i), .. }] =>
+  [{ val: StringView(s), .. }, { val: Int(i, ..), .. }] =>
     s.get_char(i).map(Char(_)) |> RuntimeValue::from_option
   _ => StringView("")
 }
@@ -194,9 +195,9 @@ let string_view_iter : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let string_view_offset_of_nth_char : RuntimeFunction = ctx => match ctx.args {
-  [{ val: StringView(s), .. }, { val: Int(n), .. }] =>
-    RuntimeValue::from_option(s.offset_of_nth_char(n).map(Int(_)))
-  _ => Int(-1)
+  [{ val: StringView(s), .. }, { val: Int(n, ..), .. }] =>
+    RuntimeValue::from_option(s.offset_of_nth_char(n).map(Int(_, raw=None)))
+  _ => Int(-1, raw=None)
 }
 
 ///|
@@ -216,7 +217,7 @@ let string_view_op_equal : RuntimeFunction = ctx => match ctx.args {
 let string_view_pad_end : RuntimeFunction = ctx => match ctx.args {
   [
     { val: StringView(s), .. },
-    { val: Int(total_width), .. },
+    { val: Int(total_width, ..), .. },
     { val: Char(padding_char), .. },
   ] => StringView(s.pad_end(total_width, padding_char))
   _ => StringView("")
@@ -226,7 +227,7 @@ let string_view_pad_end : RuntimeFunction = ctx => match ctx.args {
 let string_view_pad_start : RuntimeFunction = ctx => match ctx.args {
   [
     { val: StringView(s), .. },
-    { val: Int(total_width), .. },
+    { val: Int(total_width, ..), .. },
     { val: Char(padding_char), .. },
   ] => StringView(s.pad_start(total_width, padding_char))
   _ => StringView("")
@@ -234,7 +235,8 @@ let string_view_pad_start : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let string_view_repeat : RuntimeFunction = ctx => match ctx.args {
-  [{ val: StringView(s), .. }, { val: Int(n), .. }] => StringView(s.repeat(n))
+  [{ val: StringView(s), .. }, { val: Int(n, ..), .. }] =>
+    StringView(s.repeat(n))
   _ => StringView("")
 }
 
@@ -268,10 +270,10 @@ let string_view_rev : RuntimeFunction = ctx => match ctx.args {
 let string_view_rev_find : RuntimeFunction = ctx => match ctx.args {
   [{ val: StringView(s), .. }, { val: StringView(sub), .. }] =>
     match s.rev_find(sub) {
-      Some(i) => Int(i)
-      None => Int(-1)
+      Some(i) => Int(i, raw=None)
+      None => Int(-1, raw=None)
     }
-  _ => Int(-1)
+  _ => Int(-1, raw=None)
 }
 
 ///|
@@ -310,8 +312,8 @@ let string_view_split : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let string_view_start_offset : RuntimeFunction = ctx => match ctx.args {
-  [{ val: StringView(s), .. }] => Int(s.start_offset())
-  _ => Int(0)
+  [{ val: StringView(s), .. }] => Int(s.start_offset(), raw=None)
+  _ => Int(0, raw=None)
 }
 
 ///|
@@ -405,11 +407,11 @@ let string_view_trim_start : RuntimeFunction = ctx => match ctx.args {
 
 ///|
 let string_view_unsafe_charcode_at : RuntimeFunction = ctx => match ctx.args {
-  [{ val: StringView(s), .. }, { val: Int(i), .. }] =>
+  [{ val: StringView(s), .. }, { val: Int(i, ..), .. }] =>
     if i >= 0 && i < s.length() {
-      Int(s.unsafe_charcode_at(i))
+      Int(s.unsafe_charcode_at(i), raw=None)
     } else {
-      Int(0)
+      Int(0, raw=None)
     }
-  _ => Int(0)
+  _ => Int(0, raw=None)
 }

--- a/src/test/io_ffi.mbt
+++ b/src/test/io_ffi.mbt
@@ -14,7 +14,7 @@ test "embedded_code" {
   let vm = MoonBitVM::new()
   vm.interpreter.add_embedded_fn("%string_length2", ctx => if ctx.args
     is [{ val: String(s), .. }] {
-    Int(s.length())
+    Int(s.length(), raw=None)
   } else {
     Unit
   })


### PR DESCRIPTION
The change replaces direct access to `values` with the `env` field for storing and retrieving package constants. This provides better consistency with how other package data is accessed and makes the code more maintainable.